### PR TITLE
add an Event dispatch before the mail gets sent

### DIFF
--- a/Model/Email/Template.php
+++ b/Model/Email/Template.php
@@ -103,6 +103,15 @@ class Aschroder_SMTPPro_Model_Email_Template extends Mage_Core_Model_Email_Templ
 		
         try {
 		    
+                // adding new Event dispatch in case anyone wants to interrogate an email before being sent
+                // throwing an Exception in the Event Observer will prevent the mail being sent, 
+                // and will return false to the calling function
+                Mage::dispatchEvent('smtppro_email_before_send', array(
+                    'mail' => $mail,
+                    'template' => $this->getTemplateId(),
+                     'subject' => $this->getProcessedTemplateSubject($variables),
+                    ));
+                
         	Mage::log('About to send email');
 	        $mail->send($transport); // Zend_Mail warning..
 		    Mage::log('Finished sending email');


### PR DESCRIPTION
allows other modules to prevent an email being sent. for example, the Enterprise GiftCard email can't be stopped from being sent with native Magento. 
