### PR TITLE
Fix paths in modman file to deploy everything to their correct location

### DIFF
--- a/modman
+++ b/modman
@@ -3,5 +3,17 @@
 # author: Ashley
 
 #SMTP Pro
-*	app/code/community/Aschroder/SMTPPro/
-modules/Aschroder_SMTPPro.xml	app/etc/modules/Aschroder_SMTPPro.xml
+modules/Aschroder_SMTPPro.xml  app/etc/modules/Aschroder_SMTPPro.xml
+
+Block                                     app/code/community/Aschroder/SMTPPro/Block
+controllers                               app/code/community/Aschroder/SMTPPro/controllers
+etc                                       app/code/community/Aschroder/SMTPPro/etc
+Helper                                    app/code/community/Aschroder/SMTPPro/Helper
+Model                                     app/code/community/Aschroder/SMTPPro/Model
+sql                                       app/code/community/Aschroder/SMTPPro/sql
+
+locale/de_DE/*                            app/locale/de_DE/
+
+lib/*                                     lib/
+
+templates/adminhtml/base/default/template/smtppro/  app/design/adminhtml/default/default/template/smtppro/


### PR DESCRIPTION
Currently the modman file deploys everything under `app/code/community/Aschroder/SMTPPro/` so this pull request fixes that so that each directory goes to their correct location.

This also stops duplication of the `Aschroder_SMTPPro.xml` file.
