### PR TITLE
Allow per-website configuration

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/etc/system.xml
+++ b/app/code/local/Aschroder/SMTPPro/etc/system.xml
@@ -5,7 +5,7 @@
       <label>Aschroder Extensions</label>
       <sort_order>600</sort_order>
       <show_in_default>1</show_in_default>
-      <show_in_website>0</show_in_website>
+      <show_in_website>1</show_in_website>
       <show_in_store>0</show_in_store>
     </aschroder>
   </tabs>
@@ -17,7 +17,7 @@
       <frontend_type>text</frontend_type>
       <sort_order>110</sort_order>
       <show_in_default>1</show_in_default>
-      <show_in_website>0</show_in_website>
+      <show_in_website>1</show_in_website>
       <show_in_store>0</show_in_store>
       <groups>
         <general module="smtppro" translate="label comment">


### PR DESCRIPTION
Most configs are setup to be configured in both default & website view, but the group and section are only visible in the default view. This change fixes that.
