### PR TITLE
Resolved overwrite conflict errors not showing

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/controllers/Smtp/TestController.php
+++ b/app/code/local/Aschroder/SMTPPro/controllers/Smtp/TestController.php
@@ -67,7 +67,6 @@ class Aschroder_SMTPPro_Smtp_TestController extends Mage_Adminhtml_Controller_Ac
         if ($this->checkRewrite($this->EXPECTED_REWRITE_CLASSES["email_template_rewrite"], $email_template_rewrite)) {
             $success = false;
             $msg = $msg . "<br/>". $_helper->__("Detected overwrite conflict: %s", $email_template_rewrite);
-
             $_helper->log($_helper->__("Detected overwrite conflict: %s", $email_template_rewrite));
         }
 


### PR DESCRIPTION
Due to the extra <, the error messages were failing to render properly in the flash messages. This fix removes the extra < and allows the error to display properly.
