### PR TITLE
update: fixed grammar in SMTP Pro Self Test Results

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/controllers/Smtp/TestController.php
+++ b/app/code/local/Aschroder/SMTPPro/controllers/Smtp/TestController.php
@@ -118,7 +118,7 @@ class Aschroder_SMTPPro_Smtp_TestController extends Mage_Adminhtml_Controller_Ac
                 ->setBodyText($body);
 
         $_helper->log($_helper->__("Actual email sending test..."));
-        $msg = $msg . "<br/>". $_helper->__("Sending test email to your contact form address: ") . $to . $_helper->__(" from: ") . $this->TEST_EMAIL;
+        $msg = $msg . "<br/>". $_helper->__("Sending test email to your contact form address: ") . $to . $_helper->__(" from: {$this->TEST_EMAIL}. ");
 
         try {
 


### PR DESCRIPTION
- When a test fails, there is no space that is proceeded after the sender. Fixed this with an addition of a space.
- when a test succeeds, there is a period that proceeds from the sender. Matches all other statement sentences.