### PR TITLE
FIXED error stream_socket_enable_crypto() not supported by HHVM

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/Model/Transports/Google.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/Transports/Google.php
@@ -20,12 +20,14 @@ class Aschroder_SMTPPro_Model_Transports_Google extends Aschroder_SMTPPro_Model_
         return "smtp.gmail.com";
     }
     public function getPort($storeId) {
-        return 587;
+        if(defined('HHVM_VERSION')) return 465;
+		else return 587;
     }
     public function getAuth($storeId) {
         return 'login';
     }
     public function getSsl($storeId) {
-        return 'tls';
+		if(defined('HHVM_VERSION')) return 'ssl';
+		else return 'tls';
     }
 }

--- a/app/code/local/Aschroder/SMTPPro/Model/Transports/Google.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/Transports/Google.php
@@ -21,13 +21,13 @@ class Aschroder_SMTPPro_Model_Transports_Google extends Aschroder_SMTPPro_Model_
     }
     public function getPort($storeId) {
         if(defined('HHVM_VERSION')) return 465;
-		else return 587;
+	return 587;
     }
     public function getAuth($storeId) {
         return 'login';
     }
     public function getSsl($storeId) {
-		if(defined('HHVM_VERSION')) return 'ssl';
-		else return 'tls';
+	if(defined('HHVM_VERSION')) return 'ssl';
+	return 'tls';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,13 @@
 {
-  "name": "aschroder/smtp_pro",
+  "name": "hgati/aschroder-smtp_pro",
   "type": "magento-module",
   "description": "sending Magento mail through an external smtp-server",
-  "homepage":"https://github.com/aschroder/Magento-SMTP-Pro-Email-Extension",
+  "homepage":"https://github.com/hgati/Magento-SMTP-Pro-Email-Extension",
   "require": {
     "magento-hackathon/magento-composer-installer": "*"
   }, 
   "authors":[
-    {"name": "aschroder"
-    }
+    { "name": "hgati" }
   ],
   "extra": {
     "map" : [


### PR DESCRIPTION
I'm using by override your smtppro model.

``` xml
<smtppro>
    <rewrite>
        <transports_google>My_Patch_Model_SMTPPro_Transports_Google</transports_google>
    </rewrite>
</smtppro>
```

when using with HHVM, It occurs stream_socket_enable_crypto() error.
Change Google Apps/Gmail 'tls' to 'ssl'  if your site is accessed by HHVM.
stream_socket_enable_crypto() only used on 'tls'.
It works.
