### PR TITLE
Check ACL privileges in admin controllers

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/controllers/Smtp/LogController.php
+++ b/app/code/local/Aschroder/SMTPPro/controllers/Smtp/LogController.php
@@ -13,6 +13,11 @@
 class Aschroder_SMTPPro_Smtp_LogController
 	extends Mage_Adminhtml_Controller_Action {
 
+    protected function _isAllowed() {
+        $aclResourcePath = 'admin/system/tools/smtppro';
+        return Mage::getSingleton('admin/session')->isAllowed($aclResourcePath);
+    }
+
     protected function _initAction() {
         // load layout, set active menu and breadcrumbs
         $this->loadLayout()

--- a/app/code/local/Aschroder/SMTPPro/controllers/Smtp/TestController.php
+++ b/app/code/local/Aschroder/SMTPPro/controllers/Smtp/TestController.php
@@ -33,6 +33,11 @@ class Aschroder_SMTPPro_Smtp_TestController extends Mage_Adminhtml_Controller_Ac
         "/Connection timed out/" => "Your connection to the SMTP server timed out. Please check with your host that outbound SMTP connections are allowed as this error is most commonly caused when a host blocks outbound connections. This is probably not a bug, please do not email extension support until you have checked with your server admin or host."
     );
 
+    protected function _isAllowed() {
+        $aclResourcePath = 'admin/system/tools/smtppro_test';
+        return Mage::getSingleton('admin/session')->isAllowed($aclResourcePath);
+    }
+
     public function indexAction()
     {
         $_helper = Mage::helper('smtppro');

--- a/app/code/local/Aschroder/SMTPPro/etc/config.xml
+++ b/app/code/local/Aschroder/SMTPPro/etc/config.xml
@@ -165,9 +165,12 @@
 								</config>
 					            <tools>
 					              <children>
-					                <smtppro  translate="title" module="smtppro">
-					                  <title>Email Log</title>
-					                </smtppro>
+                                    <smtppro  translate="title" module="smtppro">
+                                        <title>Email Log</title>
+                                    </smtppro>
+                                    <smtppro_test translate="title" module="smtppro">
+                                        <title>Smtp Email Test</title>
+                                    </smtppro_test>
 					              </children>
 					            </tools>
 							</children>


### PR DESCRIPTION
Fixes access problems of users without full admin privileges to adminhtml controllers.
Sorry for the line ending conversion in TestController, the only "code change" is the implementation of `_isAllowed`.