### PR TITLE
Fix 404 Error in Adminhtml Config view due to Patch 5994

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/etc/config.xml
+++ b/app/code/local/Aschroder/SMTPPro/etc/config.xml
@@ -26,15 +26,17 @@
 		</routers>
   	</frontend>
     <admin>
-        <routers>
-            <adminhtml>
-                <args>
-                    <modules>
-                        <smtppro after="Mage_Adminhtml">Aschroder_SMTPPro</smtppro>
-                    </modules>
-                </args>
-            </adminhtml>
-        </routers>
+        <admin>
+            <routers>
+                <smtppro>
+                    <use>admin</use>
+                    <args>
+                        <module>Aschroder_SMTPPro</module>
+                        <frontName>smtppro</frontName>
+                    </args>
+                </smtppro>
+            </routers>
+        </admin>
     </admin>
 	<global>
 		<helpers>

--- a/app/code/local/Aschroder/SMTPPro/etc/config.xml
+++ b/app/code/local/Aschroder/SMTPPro/etc/config.xml
@@ -26,17 +26,15 @@
 		</routers>
   	</frontend>
     <admin>
-        <admin>
-            <routers>
-                <smtppro>
-                    <use>admin</use>
-                    <args>
-                        <module>Aschroder_SMTPPro</module>
-                        <frontName>smtppro</frontName>
-                    </args>
-                </smtppro>
-            </routers>
-        </admin>
+        <routers>
+            <smtppro>
+                <use>admin</use>
+                <args>
+                    <module>Aschroder_SMTPPro</module>
+                    <frontName>smtppro</frontName>
+                </args>
+            </smtppro>
+        </routers>
     </admin>
 	<global>
 		<helpers>


### PR DESCRIPTION
Fixed and tested on Version CE 1.9.1.0, based on this post on Stackexchange:
http://magento.stackexchange.com/questions/68411/patch-5994-is-causing-module-adminhtml-404-status-error