### PR TITLE
Make AWS region configurable

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/Helper/Data.php
+++ b/app/code/local/Aschroder/SMTPPro/Helper/Data.php
@@ -101,6 +101,11 @@ class Aschroder_SMTPPro_Helper_Data extends Mage_Core_Helper_Abstract
         return Mage::getStoreConfig('smtppro/general/ses_private_key', $storeId);
     }
 
+    public function getAmazonSESRegion($storeId = null)
+    {
+        return Mage::getStoreConfig('smtppro/general/ses_region', $storeId);
+    }
+
     public function getGoogleAppsEmail($storeId = null)
     {
         return Mage::getStoreConfig('smtppro/general/googleapps_email', $storeId);

--- a/app/code/local/Aschroder/SMTPPro/Model/System/Config/Source/Smtp/Awsregions.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/System/Config/Source/Smtp/Awsregions.php
@@ -10,14 +10,7 @@ class Aschroder_SMTPPro_Model_System_Config_Source_Smtp_Awsregions
         return array(
             'us-east-1' => Mage::helper('adminhtml')->__('US East (N. Virginia)'),
             'us-west-2' => Mage::helper('adminhtml')->__('US West (Oregon)'),
-            'us-west-1' => Mage::helper('adminhtml')->__('US West (N. California)'),
-            'eu-west-1' => Mage::helper('adminhtml')->__('EU (Ireland)'),
-            'eu-central-1' => Mage::helper('adminhtml')->__('EU (Frankfurt)'),
-            'ap-southeast-1' => Mage::helper('adminhtml')->__('Asia Pacific (Singapore)'),
-            'ap-northeast-1' => Mage::helper('adminhtml')->__('Asia Pacific (Tokyo)'),
-            'ap-southeast-2' => Mage::helper('adminhtml')->__('Asia Pacific (Sydney)'),
-            'ap-northeast-2' => Mage::helper('adminhtml')->__('Asia Pacific (Seoul)'),
-            'sa-east-1' => Mage::helper('adminhtml')->__('South America (Sao Paulo)')
+            'eu-west-1' => Mage::helper('adminhtml')->__('EU (Ireland)')
         );
     }
 }

--- a/app/code/local/Aschroder/SMTPPro/Model/System/Config/Source/Smtp/Awsregions.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/System/Config/Source/Smtp/Awsregions.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @author Fabrizio Branca
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Aschroder_SMTPPro_Model_System_Config_Source_Smtp_Awsregions
+{
+    public function toOptionArray()
+    {
+        return array(
+            'us-east-1' => Mage::helper('adminhtml')->__('US East (N. Virginia)'),
+            'us-west-2' => Mage::helper('adminhtml')->__('US West (Oregon)'),
+            'us-west-1' => Mage::helper('adminhtml')->__('US West (N. California)'),
+            'eu-west-1' => Mage::helper('adminhtml')->__('EU (Ireland)'),
+            'eu-central-1' => Mage::helper('adminhtml')->__('EU (Frankfurt)'),
+            'ap-southeast-1' => Mage::helper('adminhtml')->__('Asia Pacific (Singapore)'),
+            'ap-northeast-1' => Mage::helper('adminhtml')->__('Asia Pacific (Tokyo)'),
+            'ap-southeast-2' => Mage::helper('adminhtml')->__('Asia Pacific (Sydney)'),
+            'ap-northeast-2' => Mage::helper('adminhtml')->__('Asia Pacific (Seoul)'),
+            'sa-east-1' => Mage::helper('adminhtml')->__('South America (Sao Paulo)')
+        );
+    }
+}

--- a/app/code/local/Aschroder/SMTPPro/Model/Transports/Ses.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/Transports/Ses.php
@@ -16,7 +16,7 @@ class Aschroder_SMTPPro_Model_Transports_Ses {
 
     public function getTransport($storeId) {
 
-        $_helper = Mage::helper('smtppro');
+        $_helper = Mage::helper('smtppro'); /* @var $_helper Aschroder_SMTPPro_Helper_Data */
         $_helper->log("Getting Amazon SES Transport");
 
         $path = Mage::getModuleDir('', 'Aschroder_SMTPPro');
@@ -26,7 +26,8 @@ class Aschroder_SMTPPro_Model_Transports_Ses {
             array(
                 'accessKey' => $_helper->getAmazonSESAccessKey($storeId),
                 'privateKey' => $_helper->getAmazonSESPrivateKey($storeId)
-            )
+            ),
+            'https://email.'.$_helper->getAmazonSESRegion($storeId).'.amazonaws.com'
         );
 
         return $emailTransport;

--- a/app/code/local/Aschroder/SMTPPro/etc/config.xml
+++ b/app/code/local/Aschroder/SMTPPro/etc/config.xml
@@ -198,6 +198,7 @@
                 <mailup_password backend_model="adminhtml/system_config_backend_encrypted" />
                 <ses_access_key></ses_access_key>
                 <ses_private_key backend_model="adminhtml/system_config_backend_encrypted" />
+                <ses_region>us-east-1</ses_region>
                 <smtp_authentication></smtp_authentication>
                 <smtp_username></smtp_username>
                 <smtp_password backend_model="adminhtml/system_config_backend_encrypted" />

--- a/app/code/local/Aschroder/SMTPPro/etc/system.xml
+++ b/app/code/local/Aschroder/SMTPPro/etc/system.xml
@@ -126,6 +126,16 @@
               <show_in_store>0</show_in_store>
               <depends><option>ses</option></depends>
             </ses_private_key>
+            <ses_region translate="label">
+              <label>Amazon SES Region</label>
+              <frontend_type>select</frontend_type>
+              <source_model>smtppro/system_config_source_smtp_awsregions</source_model>
+              <sort_order>24</sort_order>
+              <show_in_default>1</show_in_default>
+              <show_in_website>1</show_in_website>
+              <show_in_store>0</show_in_store>
+              <depends><option>ses</option></depends>
+            </ses_region>
 
             <smtp_authentication translate="label">
               <label>Authentication</label>


### PR DESCRIPTION
Currently the AWS region is hardcode to us-east-1 (for Amazon SES). This PR introduces a new configuration option that let's you select your region.
