### PR TITLE
Fix queue processing with an invalid email in it

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/Model/Email/Queue.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/Email/Queue.php
@@ -125,8 +125,9 @@ class Aschroder_SMTPPro_Model_Email_Queue extends Mage_Core_Model_Email_Queue {
                     Mage::setIsDeveloperMode(true);
                     Mage::logException($e);
                     Mage::setIsDeveloperMode($oldDevMode);
-
-                    return false;
+                    
+                    $message->setProcessedAt(Varien_Date::formatDate(true));
+                    $message->save();
                 }
 
                 // after each valid message has been sent - pause if required


### PR DESCRIPTION
This pull request fixes the following bug. If a customer inputs invalid characters in his emails address (for example, ī instead of i), his email address goes to the emails queue. When Magento cron starts to process this queue, an exception is being thrown, catched, and the whole process is stopped (there's a return statement in catch block). So no emails in queue, that are added after this invalid email address, won't be sent.
This pull request keeps the exception log, but marks the failed email as processed. So other customers will get their own emails.
