### PR TITLE
Add idna-compatible mail-address encodings

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/Model/Email.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/Email.php
@@ -8,6 +8,7 @@
  * @copyright  Copyright (c) 2014 Ashley Schroder
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
+require Mage::getBaseDir().'vendor/autoload.php';
 
 class Aschroder_SMTPPro_Model_Email extends Mage_Core_Model_Email {
 
@@ -32,9 +33,10 @@ class Aschroder_SMTPPro_Model_Email extends Mage_Core_Model_Email {
         } else {
             $mail->setBodyText($this->getBody());
         }
+        $idn = new \Mso\IdnaConvert\IdnaConvert();
 
         $mail->setFrom($this->getFromEmail(), $this->getFromName())
-            ->addTo($this->getToEmail(), $this->getToName())
+            ->addTo($idn->encode($this->getToEmail()), $idn->encode($this->getToName()))
             ->setSubject($this->getSubject());
 
         $transport = new Varien_Object(); // for observers to set if required

--- a/app/code/local/Aschroder/SMTPPro/Model/Email/Queue.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/Email/Queue.php
@@ -1,5 +1,5 @@
 <?php
-
+require Mage::getBaseDir().'/vendor/autoload.php';
 /**
  * This class wraps the Queue to add email sending functionality
  * If enabled it will send emails using the given configuration.
@@ -58,6 +58,9 @@ class Aschroder_SMTPPro_Model_Email_Queue extends Mage_Core_Model_Email_Queue {
                 $mailer = new Zend_Mail('utf-8');
                 foreach ($message->getRecipients() as $recipient) {
                     list($email, $name, $type) = $recipient;
+                    $idn = new Mso\IdnaConvert\IdnaConvert();
+                    $email = $idn->encode($email);
+
                     switch ($type) {
                         case self::EMAIL_TYPE_BCC:
                             $mailer->addBcc($email, '=?utf-8?B?' . base64_encode($name) . '?=');


### PR DESCRIPTION
With Zend_Mail and punyencoding there is the problem, that Zend_Mail is
not supporting the other. By encoding it in a IDN conform way it is
possible to use non-standard letters like german Umlauts, that are
allowed in domain-names but result in "5.1.3 Bad recipient address
syntax" if send to the server, even if they are UTF-8 encoded.