### PR TITLE
 Multistore support for new order queued mails 

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/Model/Email/Queue.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/Email/Queue.php
@@ -86,13 +86,18 @@ class Aschroder_SMTPPro_Model_Email_Queue extends Mage_Core_Model_Email_Queue {
                 }
 
                 try {
-
+                    
+                    $storeId = null;
+                    if ($message->getEventType() == Mage_Sales_Model_Order::EMAIL_EVENT_NAME_NEW_ORDER){
+                        $storeId = Mage::getModel('sales/order')->load($message->getEntityId())->getStore()->getId();
+                    }
 
                     $transport = new Varien_Object();
                     Mage::dispatchEvent('aschroder_smtppro_queue_before_send', array(
                         'mail' => $mailer,
                         'transport' => $transport,
-                        'message' => $message
+                        'message' => $message,
+                        'store_id' => $storeId
                     ));
 
                     if ($transport->getTransport()) { // if set by an observer, use it

--- a/app/code/local/Aschroder/SMTPPro/Model/Observer.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/Observer.php
@@ -63,7 +63,7 @@ class Aschroder_SMTPPro_Model_Observer extends Varien_Object {
 
     public function beforeSendQueue($observer) {
         Mage::helper('smtppro')->log($observer->getEvent()->getMail());
-        $observer->getEvent()->getTransport()->setTransport(Mage::helper('smtppro')->getTransport());
+        $observer->getEvent()->getTransport()->setTransport(Mage::helper('smtppro')->getTransport($observer->getEvent()->getStoreId()));
     }
 	
 }


### PR DESCRIPTION
Pass **store_id** as parameter in `Mage::helper('smtppro')->getTransport()` calls at `beforeSendQueue` observer method