### PR TITLE
infinite loop if Recipient address rejected

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/Model/Email/Queue.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/Email/Queue.php
@@ -121,6 +121,8 @@ class Aschroder_SMTPPro_Model_Email_Queue extends Mage_Core_Model_Email_Queue {
                 }
                 catch (Exception $e) {
                     unset($mailer);
+                    $message->setProcessedAt(Varien_Date::formatDate(true));
+                    $message->save();
                     $oldDevMode = Mage::getIsDeveloperMode();
                     Mage::setIsDeveloperMode(true);
                     Mage::logException($e);


### PR DESCRIPTION
if smtp fail with a presistente error like:
5.7.1 \<email@example.com>: Recipient address rejected: Dominio non valido / Invalid Domai

the exception is reported but the mail is not marked as processed causing the attempt to be sent to every cron

it would be interesting to manage smtp errors and report them in smtppro_email_log perhaps adding a column to save the error
but for the moment this hard fix is ​​enough to avoid the infinite attempt to send and there is still a trace of the error in the exception log