### PR TITLE
Clear recipients to avoid to send too much emails

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/Model/Email/Template.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/Email/Template.php
@@ -76,6 +76,7 @@ class Aschroder_SMTPPro_Model_Email_Template extends Mage_Core_Model_Email_Templ
 
             /** @var $emailQueue Mage_Core_Model_Email_Queue */
             $emailQueue = $this->getQueue();
+            $emailQueue->clearRecipients();
             $emailQueue->setMessageBody($text);
             $emailQueue->setMessageParameters(array(
                 'subject'           => $subject,


### PR DESCRIPTION
Clear recipient to avoid too much email sent

Done by the core :

![image](https://github.com/aschroder/Magento-SMTP-Pro-Email-Extension/assets/11380627/645bcd44-1623-43e7-b47e-847381d53fe7)

Examples : 

![image psd](https://github.com/aschroder/Magento-SMTP-Pro-Email-Extension/assets/11380627/9dd15bb1-7a63-4a3e-9c19-1b35becb4be5)

